### PR TITLE
Mac Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ First, clone this repo into your sublime packages folder(it doesn't use Package 
 
 This will build the `complete.so` binary. It requires development versions of Clang and Python 3.4 to build(packages `python3.4-dev` and `libclang-dev` on debian-based distros).
 
+Installation Mac
+------------
+Download [Homebrew] (http://www.brew.sh) and install llvm using brew by running 
+`brew install llvm`
+then cd into the `complete` directory and type:
+````
+    make mac 
+````
+
+
 Usage
 -----
 

--- a/complete/Makefile
+++ b/complete/Makefile
@@ -1,8 +1,9 @@
 CXX=g++
 
-CLANG_PREFIX=$(shell (cd /usr/local/include/clang-c/ && cd ../.. && pwd) 2> /dev/null || (cd /usr/lib/llvm-3.5/ && pwd) 2> /dev/null || (cd /usr/lib/llvm-3.4/ && pwd) 2> /dev/null || (cd /usr/lib/llvm-3.3/ && pwd) 2> /dev/null)
+CLANG_PREFIX=$(shell (cd /usr/local/include/clang-c/ && cd ../.. && pwd) 2> /dev/null || (cd /usr/lib/llvm-3.5/ && pwd) 2> /dev/null || (cd /usr/lib/llvm-3.4/ && pwd) 2> /dev/null || (cd /usr/lib/llvm-3.3/ && pwd) 2> /dev/null || (cd /usr/local/Cellar/llvm/3.5.1 && pwd) 2> /dev/null)
 CLANG_FLAGS=-I$(CLANG_PREFIX)/include/
-CLANG_LIBS=-L$(CLANG_PREFIX)/lib/ -Wl,-rpath=$(CLANG_PREFIX)/lib -lclang
+CLANG_LIBS=-L$(CLANG_PREFIX)/lib/ -Wl,-rpath $(CLANG_PREFIX)/lib -lclang
+
 
 FLAGS=$(CLANG_FLAGS)
 LIBS=$(CLANG_LIBS)
@@ -19,3 +20,6 @@ debug:
 log:
 	$(CXX) -std=gnu++0x $(FLAGS) -Os -c -fPIC -DCLANG_COMPLETE_LOG $(SRC).cpp -o $(SRC).o
 	$(CXX) -shared -Wl,-soname,$(LIB_NAME).so -o $(LIB_NAME).so $(SRC).o $(LIBS)
+mac: 
+	$(CXX) -std=gnu++0x $(FLAGS) -DNDEBUG -Os -c -fPIC complete.cpp -o $(SRC).o
+	$(CXX) -shared -Wl,-install_name,$(LIB_NAME).so -o $(LIB_NAME).so $(SRC).o $(LIBS)

--- a/complete/complete.cpp
+++ b/complete/complete.cpp
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <cstring>
 #include <cassert>
+#include <vector>
 
 #include "complete.h"
 


### PR DESCRIPTION
I removed the mac version of the Makefile now I just added `make mac` command since on mac you have to use -install_name inserted of `-soname`
Also the `-rpath` flag doesn't need an equal sign on a mac, in fact it will crash if there is an equal sign. But I am not sure if it's required on Linux. And I add `#include <vector>` to the complete.cpp file since it won't compile on a mac without it. 