### PR TITLE
Ignore silly clang warning that cannot be suppressed.

### DIFF
--- a/clangcomplete.py
+++ b/clangcomplete.py
@@ -465,7 +465,7 @@ class ClangCompleteAutoComplete(sublime_plugin.EventListener):
         return [diag for diag in diagnostics]
 
     def show_diagnostics(self, view):
-        output = '\n'.join(self.diagnostics(view))
+        output = '\n'.join([line for line in self.diagnostics(view) if "#pragma once in main file" not in line])
         clang_error_panel.set_data(output)
         window = view.window()
         if not window is None and len(output) > 1:


### PR DESCRIPTION
Avoids having to close diagnostics window on every save of a perfectly
valid header file.