### PR TITLE
Fix memory leak

### DIFF
--- a/complete/complete.cpp
+++ b/complete/complete.cpp
@@ -662,7 +662,7 @@ public:
             // If we are busy with a query, lets avoid making lots of new queries
             if (not this->q.ready()) return {};
             
-            auto self = this->shared_from_this();
+            std::weak_ptr<async_translation_unit> self = this->shared_from_this();
             std::string buffer_as_string(buffer, buffer+len);
             this->q.set(detach_async([=]
             {
@@ -670,7 +670,14 @@ public:
                 if (buffer == nullptr) b = nullptr;
                 // TODO: Should we always reparse?
                 // else this->reparse(b, len);
-                return self->complete_at(line, col, "", b, buffer_as_string.length());
+                if (auto s = self.lock())
+                {
+                    return s->complete_at(line, col, "", b, buffer_as_string.length());
+                }
+                else
+                {
+                    return std::vector<completion>();
+                }
             }), line, col);
         }
         auto completions = q.get(timeout);


### PR DESCRIPTION
While it is not possible to have the 'old' memory leaks with smart pointer it
is possible to waste memory still. By adding a shared_ptr of this to the
lambda, that is added to the queue of this the smart pointer can't delete this
object.

The memory leak appears if the user frees the cache (free_all is called)