### PR TITLE
Fix include paths with spaces

### DIFF
--- a/clangcomplete.py
+++ b/clangcomplete.py
@@ -45,7 +45,7 @@ def parse_flags(f):
     flags = []
     for line in open(f).readlines():
         if line.startswith('CXX_FLAGS') or line.startswith('CXX_DEFINES') or line.startswith('CXX_INCLUDES'):
-            words = re.findall('(-[^\s\"]+\"[^\"]+\"|-[^\s]*)',line[line.index('=')+1:])
+            words = re.findall('(-[^\s\"]+\"[^\"]+\"|[^\s]+)',line[line.index('=')+1:])
             flags.extend([word for word in words if not word.startswith('-g')])
     return flags
 

--- a/clangcomplete.py
+++ b/clangcomplete.py
@@ -45,7 +45,7 @@ def parse_flags(f):
     flags = []
     for line in open(f).readlines():
         if line.startswith('CXX_FLAGS') or line.startswith('CXX_DEFINES') or line.startswith('CXX_INCLUDES'):
-            words = line[line.index('=')+1:].split()
+            words = re.findall('(-[^\s\"]+\"[^\"]+\"|-[^\s]*)',line[line.index('=')+1:])
             flags.extend([word for word in words if not word.startswith('-g')])
     return flags
 
@@ -92,7 +92,15 @@ def filter_flag(f):
 def split_flags(flags):
     result = []
     for f in flags:
-        if filter_flag(f): result.extend(f.split())
+        fm = re.match('(^-[^\s\"]+)(\"[^\"]+\"$)', f)
+        if fm:
+            option = fm.group(1)
+            path = fm.group(2)
+            path = path.replace('"','')
+
+            result.append(option)
+            result.append(path)
+        elif filter_flag(f): result.extend(f.split())
     return result
 
 def accumulate_options(path):

--- a/complete/complete.cpp
+++ b/complete/complete.cpp
@@ -376,7 +376,7 @@ public:
     translation_unit(const char * filename, const char ** args, int argv) : filename(filename)
     {
         // this->index = clang_createIndex(1, 1);
-        this->tu = clang_parseTranslationUnit(get_index(), filename, args, argv, NULL, 0, parse_options());
+        this->tu = clang_createTranslationUnitFromSourceFile(get_index(), filename, argv, args, 0, nullptr );
         detach_async([=]() { this->reparse(); });
     }
 


### PR DESCRIPTION
If a space was previously in the include path found in the CMake file the path
would be split at the space in separate arguments that lead to ill formed
include arguments. Further did the clang_parseTranslationUnit not interpret
the paths correctly what clang_createTranslationUnitFromSourceFile does.

The regex does not work if a path contains a " but I hope no one uses something
like that

Thank you for merging my work! :+1:  