### PR TITLE
Fix missing CMake options

### DIFF
--- a/clangcomplete.py
+++ b/clangcomplete.py
@@ -101,8 +101,7 @@ def accumulate_options(path):
         for f in filenames:
             if f.endswith('compile_commands.json'):
                flags.extend(merge_flags(parse_compile_commands(root, f), flags))
-               return split_flags(flags);
-            if f.endswith('flags.make'): 
+            if f.endswith('flags.make'):
                 flags.extend(merge_flags(parse_flags(os.path.join(root, f)), flags))
     return split_flags(flags)
 


### PR DESCRIPTION
If the current directory contains a 'compile_commands.json' file the loop is
left early.